### PR TITLE
[PW-26] 자동완성 기능을 구현했습니다. 정말 간단하게 ES만 조회합니다.

### DIFF
--- a/infra/docker-compose/elasticsearch/Dockerfile
+++ b/infra/docker-compose/elasticsearch/Dockerfile
@@ -2,3 +2,4 @@ ARG ELK_VERSION
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ELK_VERSION}
 # nori 형태소 분석기 플러그인 설치
 RUN elasticsearch-plugin install analysis-nori --batch
+RUN bin/opensearch-plugin install analysis-icu

--- a/infra/docker-compose/elasticsearch/Dockerfile
+++ b/infra/docker-compose/elasticsearch/Dockerfile
@@ -2,4 +2,4 @@ ARG ELK_VERSION
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ELK_VERSION}
 # nori 형태소 분석기 플러그인 설치
 RUN elasticsearch-plugin install analysis-nori --batch
-RUN bin/opensearch-plugin install analysis-icu
+RUN elasticsearch-plugin install analysis-icu --batch

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionSearchServiceImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionSearchServiceImpl.java
@@ -66,4 +66,9 @@ public class AdoptionSearchServiceImpl implements AdoptionSearchService {
         return adoptionAiService.embed(refinedSearchTerm);
     }
 
+    @Override
+    public List<String> autocomplete(String keyword) {
+        return adoptionSearchRepository.autocomplete(keyword);
+    }
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/port/AdoptionSearchRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/port/AdoptionSearchRepository.java
@@ -14,4 +14,6 @@ public interface AdoptionSearchRepository {
     // 검색 결과의 전체 metadata 포함
     SearchHits<AdoptionDocument> searchSimilarAdoptionSearchHits(AdoptionSearchCondition condition);
 
+    // 자동 완성
+    List<String> autocomplete(String keyword);
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/AdoptionSearchRepositoryImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/AdoptionSearchRepositoryImpl.java
@@ -7,7 +7,9 @@ import kr.co.pawong.pwbe.adoption.application.domain.Adoption;
 import kr.co.pawong.pwbe.adoption.application.service.dto.request.AdoptionSearchCondition;
 import kr.co.pawong.pwbe.adoption.application.service.port.AdoptionSearchRepository;
 import kr.co.pawong.pwbe.adoption.infrastructure.repository.document.AdoptionDocument;
+import kr.co.pawong.pwbe.adoption.infrastructure.repository.document.AutocompleteDocument;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
@@ -16,6 +18,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 @Repository
 @RequiredArgsConstructor
@@ -108,5 +111,28 @@ public class AdoptionSearchRepositoryImpl implements AdoptionSearchRepository {
         }
 
         return semantic.build()._toQuery();
+    }
+
+    @Override
+    public List<String> autocomplete(String keyword) {
+        var edgeQuery = NativeQuery.builder()
+                .withQuery(q -> q.match(m -> m.field("word.edge").query(keyword)))
+                .withPageable(PageRequest.of(0, 1000))
+                .build();
+        var ngramQuery = NativeQuery.builder()
+                .withQuery(q -> q.bool(b -> b
+                        .must(m1 -> m1.match(m2 -> m2.field("word.ngram").query(keyword)))
+                        .mustNot(mn -> mn.match(mn2 -> mn2.field("word.edge").query(keyword)))
+                ))
+                .withPageable(PageRequest.of(0, 1000))
+                .build();
+
+        return Stream.concat(
+                        elasticsearchOperations.search(edgeQuery, AutocompleteDocument.class)
+                                .stream().map(hit -> hit.getContent().getWord()),
+                        elasticsearchOperations.search(ngramQuery, AutocompleteDocument.class)
+                                .stream().map(hit -> hit.getContent().getWord())
+                )
+                .toList();
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/document/AutocompleteDocument.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/document/AutocompleteDocument.java
@@ -1,0 +1,22 @@
+package kr.co.pawong.pwbe.adoption.infrastructure.repository.document;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(indexName = "autocomplete")
+public class AutocompleteDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Text, name = "word")
+    private String word;
+}

--- a/src/main/java/kr/co/pawong/pwbe/adoption/presentation/controller/AdoptionSearchController.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/presentation/controller/AdoptionSearchController.java
@@ -1,12 +1,15 @@
 package kr.co.pawong.pwbe.adoption.presentation.controller;
 
 import kr.co.pawong.pwbe.adoption.presentation.controller.dto.request.AdoptionSearchRequest;
+import kr.co.pawong.pwbe.adoption.presentation.controller.dto.response.AdoptionAutocompleteResponse;
 import kr.co.pawong.pwbe.adoption.presentation.controller.dto.response.AdoptionSearchResponses;
 import kr.co.pawong.pwbe.adoption.presentation.controller.dto.response.AdoptionIdSearchResponses;
 import kr.co.pawong.pwbe.adoption.presentation.port.AdoptionSearchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequestMapping("/api/adoptions")
 @RestController
@@ -26,5 +29,15 @@ public class AdoptionSearchController {
     public ResponseEntity<AdoptionIdSearchResponses> searchDocumentIds(@ModelAttribute AdoptionSearchRequest request) {
         AdoptionIdSearchResponses response = adoptionSearchService.searchDocumentIds(request);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/search/autocomplete")
+    public ResponseEntity<AdoptionAutocompleteResponse> searchAutoComplete(
+            @RequestParam String keyword
+    ) {
+        List<String> autocomplete = adoptionSearchService.autocomplete(keyword);
+        return ResponseEntity.ok(
+                new AdoptionAutocompleteResponse(autocomplete)
+        );
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/presentation/controller/dto/response/AdoptionAutocompleteResponse.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/presentation/controller/dto/response/AdoptionAutocompleteResponse.java
@@ -1,0 +1,12 @@
+package kr.co.pawong.pwbe.adoption.presentation.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AdoptionAutocompleteResponse {
+    private List<String> autocompletes;
+}

--- a/src/main/java/kr/co/pawong/pwbe/adoption/presentation/port/AdoptionSearchService.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/presentation/port/AdoptionSearchService.java
@@ -5,6 +5,8 @@ import kr.co.pawong.pwbe.adoption.presentation.controller.dto.response.AdoptionS
 import kr.co.pawong.pwbe.adoption.presentation.controller.dto.response.AdoptionIdSearchResponses;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public interface AdoptionSearchService {
 
@@ -13,4 +15,7 @@ public interface AdoptionSearchService {
 
     // ES에서 조회해서 adoptionIds 반환
     AdoptionIdSearchResponses searchDocumentIds(AdoptionSearchRequest request);
+
+    // ES에서 조회해서 자동완성 리스트 반환
+    List<String> autocomplete(String keyword);
 }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#26 -> develop

### 변경 사항
일단 만들어봤는데 수정할게 있으면 바로 말씀해주세요. 감사합니다!
- **구현 사항**
자동완성 기능을 구현했습니다.
그냥 ES에 쿼리 날리고 그 결과를 그대로 반환하는 api를 만들었습니다.
자동완성을 위해서 별개의 Document를 만들었습니다.
해당 Document 생성 쿼리는 Notion의 연락처/계정 페이지에 두었습니다.
- **Document를 별개로 만든 이유**
자동 완성이라는 것은 검색하면 좋을 키워드를 추천해주는 거라 생각해서, 자동 완성으로 추천해줄 단어들을 따로 관리하는게 좋아보였습니다.

### PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과
![image](https://github.com/user-attachments/assets/5a1c3be7-b25d-490b-b3e3-1f22fb6969fc)
![image](https://github.com/user-attachments/assets/2c60398e-15b1-4b7f-bb3e-395d687e7407)
