### PR TITLE
[PW-23] Adoption-Shelter port-adapter 구조 보호소정보 요청-반환

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/domain/Adoption.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/domain/Adoption.java
@@ -36,6 +36,7 @@ public class Adoption {
     private SexCd sexCd; // 성별
     private NeuterYn neuterYn; // 중성화여부(타입)
     private String specialMark; // 특징
+    private String careRegNo; // 보호소 번호
     private LocalDateTime updTm; // 수정일
     private Shelter shelter; // 보호소id(외래키)
 
@@ -62,6 +63,7 @@ public class Adoption {
                 .sexCd(adoptionCreate.getSexCd())
                 .neuterYn(adoptionCreate.getNeuterYn())
                 .specialMark(adoptionCreate.getSpecialMark())
+                .careRegNo(adoptionCreate.getCareRegNo())
                 .updTm(adoptionCreate.getUpdTm())
                 .shelter(adoptionCreate.getShelter())
                 .build();
@@ -91,6 +93,7 @@ public class Adoption {
                 .sexCd(adoptionUpdate.getSexCd())
                 .neuterYn(adoptionUpdate.getNeuterYn())
                 .specialMark(adoptionUpdate.getSpecialMark())
+                .careRegNo(adoptionUpdate.getCareRegNo())
                 .updTm(adoptionUpdate.getUpdTm())
                 .shelter(adoptionUpdate.getShelter())
                 .build();

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/domain/AdoptionCreate.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/domain/AdoptionCreate.java
@@ -39,6 +39,7 @@ public class AdoptionCreate {
     private SexCd sexCd; // 성별
     private NeuterYn neuterYn; // 중성화여부(타입)
     private String specialMark; // 특징
+    private String careRegNo; // 보호소 번호
     private LocalDateTime updTm; // 수정일
     private Shelter shelter; // 보호소id(외래키)
 

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/domain/AdoptionUpdate.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/domain/AdoptionUpdate.java
@@ -40,6 +40,7 @@ public class AdoptionUpdate {
     private SexCd sexCd; // 성별
     private NeuterYn neuterYn; // 중성화여부(타입)
     private String specialMark; // 특징
+    private String careRegNo; // 보호소 번호
     private LocalDateTime updTm; // 수정일
     private Shelter shelter; // 보호소id(외래키)
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionQueryServiceImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionQueryServiceImpl.java
@@ -1,5 +1,28 @@
 package kr.co.pawong.pwbe.adoption.application.service;
 
-public class AdoptionQueryServiceImpl {
+import kr.co.pawong.pwbe.adoption.application.service.port.AdoptionQueryRepository;
+import kr.co.pawong.pwbe.adoption.presentation.port.AdoptionQueryService;
+import kr.co.pawong.pwbe.shelter.infrastructure.adapter.ShelterAdapter;
+import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdoptionQueryServiceImpl implements AdoptionQueryService {
+
+    private final AdoptionQueryRepository adoptionQueryRepository;
+    private final ShelterAdapter shelterAdapter;
+
+    @Override
+    public ShelterInfoDto findShelterInfoByAdoptionId(Long adoptionId) {
+        // 1) AdoptionEntity에서 careRegNo 조회
+        String careRegNo = adoptionQueryRepository.findCareRegNoByAdoptionId(adoptionId);
+        // 2) ShelterAdapter 통해 실제 Shelter 컨텍스트에 질의
+        return shelterAdapter.getShelterInfo(careRegNo);
+    }
 
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionQueryServiceImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionQueryServiceImpl.java
@@ -4,6 +4,7 @@ import kr.co.pawong.pwbe.adoption.application.domain.Adoption;
 import kr.co.pawong.pwbe.adoption.application.service.dto.response.AdoptionCard;
 import kr.co.pawong.pwbe.adoption.application.service.dto.response.SliceAdoptionSearchResponses;
 import kr.co.pawong.pwbe.adoption.application.service.port.AdoptionQueryRepository;
+import kr.co.pawong.pwbe.adoption.application.service.port.ShelterInfoPort;
 import kr.co.pawong.pwbe.adoption.application.service.support.AdoptionCardMapper;
 import kr.co.pawong.pwbe.adoption.presentation.port.AdoptionQueryService;
 import lombok.RequiredArgsConstructor;
@@ -24,14 +25,15 @@ import lombok.extern.slf4j.Slf4j;
 public class AdoptionQueryServiceImpl implements AdoptionQueryService {
 
     private final AdoptionQueryRepository adoptionQueryRepository;
-    private final ShelterAdapter shelterAdapter;
+
+    private final ShelterInfoPort shelterInfoPort;
 
     @Override
     public ShelterInfoDto findShelterInfoByAdoptionId(Long adoptionId) {
         // 1) AdoptionEntity에서 careRegNo 조회
         String careRegNo = adoptionQueryRepository.findCareRegNoByAdoptionId(adoptionId);
         // 2) ShelterAdapter 통해 실제 Shelter 컨텍스트에 질의
-        return shelterAdapter.getShelterInfo(careRegNo);
+        return shelterInfoPort.getShelterInfo(careRegNo);
     }
 
     // infinite scroll을 위한 slice 방식

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/ApiRequestService.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/ApiRequestService.java
@@ -103,6 +103,7 @@ public class ApiRequestService {
                                 .sexCd(convertToEnum(item.getSexCd(), SexCd.class))
                                 .neuterYn(convertToEnum(item.getNeuterYn(), NeuterYn.class))
                                 .specialMark(item.getSpecialMark())
+                                .careRegNo(item.getCareRegNo())
                                 .updTm(updTm)
                                 .build();
 

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/port/AdoptionQueryRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/port/AdoptionQueryRepository.java
@@ -2,4 +2,6 @@ package kr.co.pawong.pwbe.adoption.application.service.port;
 
 public interface AdoptionQueryRepository {
 
+    String findCareRegNoByAdoptionId(Long id);
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/port/ShelterInfoPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/port/ShelterInfoPort.java
@@ -1,0 +1,7 @@
+package kr.co.pawong.pwbe.adoption.application.service.port;
+
+import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
+
+public interface ShelterInfoPort {
+    ShelterInfoDto getShelterInfo(String careRegNo);
+}

--- a/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/AdoptionJpaRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/AdoptionJpaRepository.java
@@ -4,4 +4,6 @@ import kr.co.pawong.pwbe.adoption.infrastructure.repository.entity.AdoptionEntit
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdoptionJpaRepository extends JpaRepository<AdoptionEntity, Long> {
+
+    
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/AdoptionJpaRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/AdoptionJpaRepository.java
@@ -2,8 +2,15 @@ package kr.co.pawong.pwbe.adoption.infrastructure.repository;
 
 import kr.co.pawong.pwbe.adoption.infrastructure.repository.entity.AdoptionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AdoptionJpaRepository extends JpaRepository<AdoptionEntity, Long> {
 
-    
+//    String findCareRegNoByAdoptionId(Long id)
+
+    @Query("SELECT a.careRegNo FROM AdoptionEntity a WHERE a.adoptionId = :id")
+    String findCareRegNoByAdoptionId(@Param("id") Long id);
+
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/AdoptionQueryRepositoryImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/AdoptionQueryRepositoryImpl.java
@@ -1,5 +1,21 @@
 package kr.co.pawong.pwbe.adoption.infrastructure.repository;
 
-public class AdoptionQueryRepositoryImpl {
+import kr.co.pawong.pwbe.adoption.application.service.port.AdoptionQueryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class AdoptionQueryRepositoryImpl implements AdoptionQueryRepository {
+
+    private final AdoptionJpaRepository adoptionJpaRepository;
+
+    @Override
+    public String findCareRegNoByAdoptionId(Long id) {
+        return adoptionJpaRepository.findCareRegNoByAdoptionId(id);
+    }
 
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/entity/AdoptionEntity.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/entity/AdoptionEntity.java
@@ -84,6 +84,8 @@ public class AdoptionEntity {
 
     private String specialMark; // 특징
 
+    private String careRegNo; // 보호소 번호
+
     private LocalDateTime updTm; // 수정일
 
     @ManyToOne
@@ -115,6 +117,7 @@ public class AdoptionEntity {
         entity.sexCd = adoption.getSexCd();
         entity.neuterYn = adoption.getNeuterYn();
         entity.specialMark = adoption.getSpecialMark();
+        entity.careRegNo = adoption.getCareRegNo();
         entity.updTm = adoption.getUpdTm();
         entity.shelterEntity = null;
                 //ShelterEntity.from(adoption.getShelter());
@@ -149,6 +152,7 @@ public class AdoptionEntity {
                 .sexCd(sexCd)
                 .neuterYn(neuterYn)
                 .specialMark(specialMark)
+                .careRegNo(careRegNo)
                 .updTm(updTm)
                 .shelter(shelter)
                 .build();

--- a/src/main/java/kr/co/pawong/pwbe/adoption/presentation/controller/AdoptionUpdateController.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/presentation/controller/AdoptionUpdateController.java
@@ -3,14 +3,13 @@ package kr.co.pawong.pwbe.adoption.presentation.controller;
 import java.util.List;
 import kr.co.pawong.pwbe.adoption.application.domain.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.service.ApiRequestService;
+import kr.co.pawong.pwbe.adoption.presentation.port.AdoptionQueryService;
 import kr.co.pawong.pwbe.adoption.presentation.port.AdoptionUpdateService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -20,6 +19,7 @@ public class AdoptionUpdateController {
 
     private final ApiRequestService apiRequestService;
     private final AdoptionUpdateService adoptionUpdateService;
+    private final AdoptionQueryService adoptionQueryService;
 
     @PostMapping("/save")
     public ResponseEntity<Void> saveAdoptions() {
@@ -29,5 +29,11 @@ public class AdoptionUpdateController {
         log.info("총 {}개의 입양동물 데이터가 성공적으로 저장되었습니다.", adoptionCreates.size());
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/info/{id}")
+    public void carRegNoinfo(@PathVariable("id")Long id){
+        String carRegNO = adoptionQueryService.findCarRegNoByAdoptionId(id);
+        log.info("carRegNO: {}", carRegNO);
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/presentation/controller/AdoptionUpdateController.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/presentation/controller/AdoptionUpdateController.java
@@ -32,14 +32,14 @@ public class AdoptionUpdateController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @GetMapping("/{id}/shelter")
-    public ShelterInfoDto getShelterInfo(@PathVariable Long id) {
-
-        ShelterInfoDto dto = adoptionQueryService.findShelterInfoByAdoptionId(id);
-        log.info("◀ 반환: ShelterInfoDto(careRegNo={}, city={}, district={})",
-                dto.getCareRegNo(), dto.getCity(), dto.getDistrict());
-
-        return dto;
-    }
+//    @GetMapping("/{id}/shelter")
+//    public ShelterInfoDto getShelterInfo(@PathVariable Long id) {
+//
+//        ShelterInfoDto dto = adoptionQueryService.findShelterInfoByAdoptionId(id);
+//        log.info("◀ 반환: ShelterInfoDto(careRegNo={}, city={}, district={})",
+//                dto.getCareRegNo(), dto.getCity(), dto.getDistrict());
+//
+//        return dto;
+//    }
 
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/presentation/controller/AdoptionUpdateController.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/presentation/controller/AdoptionUpdateController.java
@@ -5,6 +5,7 @@ import kr.co.pawong.pwbe.adoption.application.domain.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.service.ApiRequestService;
 import kr.co.pawong.pwbe.adoption.presentation.port.AdoptionQueryService;
 import kr.co.pawong.pwbe.adoption.presentation.port.AdoptionUpdateService;
+import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -31,9 +32,14 @@ public class AdoptionUpdateController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @GetMapping("/info/{id}")
-    public void carRegNoinfo(@PathVariable("id")Long id){
-        String carRegNO = adoptionQueryService.findCarRegNoByAdoptionId(id);
-        log.info("carRegNO: {}", carRegNO);
+    @GetMapping("/{id}/shelter")
+    public ShelterInfoDto getShelterInfo(@PathVariable Long id) {
+
+        ShelterInfoDto dto = adoptionQueryService.findShelterInfoByAdoptionId(id);
+        log.info("◀ 반환: ShelterInfoDto(careRegNo={}, city={}, district={})",
+                dto.getCareRegNo(), dto.getCity(), dto.getDistrict());
+
+        return dto;
     }
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/presentation/port/AdoptionQueryService.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/presentation/port/AdoptionQueryService.java
@@ -1,5 +1,10 @@
 package kr.co.pawong.pwbe.adoption.presentation.port;
 
+import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
+
 public interface AdoptionQueryService {
 
+//    String findCarRegNoByAdoptionId(Long id);
+
+    ShelterInfoDto findShelterInfoByAdoptionId(Long adoptionId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/ShelterQueryServiceImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/ShelterQueryServiceImpl.java
@@ -4,18 +4,21 @@ import kr.co.pawong.pwbe.shelter.application.service.port.ShelterQueryRepository
 import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
 import kr.co.pawong.pwbe.shelter.presentation.port.ShelterQueryService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-@Slf4j
-@Service
 @RequiredArgsConstructor
+@Service
 public class ShelterQueryServiceImpl implements ShelterQueryService {
 
     private final ShelterQueryRepository shelterQueryRepository;
 
     @Override
     public ShelterInfoDto shelterInfo(String careRegNo) {
-        return shelterQueryRepository.shelterInfo(careRegNo);
+        // Repository 통해 Entity 조회
+        var entity = shelterQueryRepository.findByCareRegNo(careRegNo);
+        // DTO로 변환
+        return new ShelterInfoDto(entity.getCareRegNo(),
+                entity.getCity(),
+                entity.getDistrict());
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/ShelterQueryServiceImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/ShelterQueryServiceImpl.java
@@ -1,0 +1,20 @@
+package kr.co.pawong.pwbe.shelter.application.service;
+
+import kr.co.pawong.pwbe.shelter.application.service.port.ShelterQueryRepository;
+import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
+import kr.co.pawong.pwbe.shelter.presentation.port.ShelterQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ShelterQueryServiceImpl implements ShelterQueryService {
+
+    private final ShelterQueryRepository shelterQueryRepository;
+
+    public ShelterInfoDto shelterInfo(String careRegNo) {
+        return shelterQueryRepository.shelterInfo(careRegNo);
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/ShelterQueryServiceImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/ShelterQueryServiceImpl.java
@@ -14,6 +14,7 @@ public class ShelterQueryServiceImpl implements ShelterQueryService {
 
     private final ShelterQueryRepository shelterQueryRepository;
 
+    @Override
     public ShelterInfoDto shelterInfo(String careRegNo) {
         return shelterQueryRepository.shelterInfo(careRegNo);
     }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/ShelterUpdateServiceImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/ShelterUpdateServiceImpl.java
@@ -3,7 +3,7 @@ package kr.co.pawong.pwbe.shelter.application.service;
 import kr.co.pawong.pwbe.shelter.application.domain.Shelter;
 import kr.co.pawong.pwbe.shelter.application.domain.ShelterCreate;
 import kr.co.pawong.pwbe.shelter.application.service.port.ShelterUpdateRepository;
-import kr.co.pawong.pwbe.shelter.presentation.controller.port.ShelterUpdateService;
+import kr.co.pawong.pwbe.shelter.presentation.port.ShelterUpdateService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/port/ShelterQueryRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/port/ShelterQueryRepository.java
@@ -1,8 +1,11 @@
 package kr.co.pawong.pwbe.shelter.application.service.port;
 
+import kr.co.pawong.pwbe.shelter.infrastructure.repository.entity.ShelterEntity;
 import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
 
 public interface ShelterQueryRepository {
 
     ShelterInfoDto shelterInfo(String careRegNo);
+
+    ShelterEntity findByCareRegNo(String careRegNo);
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/port/ShelterQueryRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/port/ShelterQueryRepository.java
@@ -1,0 +1,8 @@
+package kr.co.pawong.pwbe.shelter.application.service.port;
+
+import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
+
+public interface ShelterQueryRepository {
+
+    ShelterInfoDto shelterInfo(String careRegNo);
+}

--- a/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/adapter/ShelterAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/adapter/ShelterAdapter.java
@@ -1,0 +1,20 @@
+package kr.co.pawong.pwbe.shelter.infrastructure.adapter;
+
+import kr.co.pawong.pwbe.shelter.application.service.port.ShelterQueryRepository;
+import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
+import kr.co.pawong.pwbe.shelter.presentation.port.ShelterQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ShelterAdapter {
+
+    private final ShelterQueryService shelterQueryService;
+
+    public ShelterInfoDto getShelterInfo(String careRegNo) {
+        return shelterQueryService.shelterInfo(careRegNo);
+    }
+
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/adapter/ShelterAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/adapter/ShelterAdapter.java
@@ -1,6 +1,5 @@
 package kr.co.pawong.pwbe.shelter.infrastructure.adapter;
 
-import kr.co.pawong.pwbe.shelter.application.service.port.ShelterQueryRepository;
 import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
 import kr.co.pawong.pwbe.shelter.presentation.port.ShelterQueryService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/adapter/ShelterAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/adapter/ShelterAdapter.java
@@ -1,5 +1,6 @@
 package kr.co.pawong.pwbe.shelter.infrastructure.adapter;
 
+import kr.co.pawong.pwbe.adoption.application.service.port.ShelterInfoPort;
 import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
 import kr.co.pawong.pwbe.shelter.presentation.port.ShelterQueryService;
 import lombok.RequiredArgsConstructor;
@@ -7,10 +8,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ShelterAdapter {
+public class ShelterAdapter implements ShelterInfoPort {
 
     private final ShelterQueryService shelterQueryService;
 
+    @Override
     public ShelterInfoDto getShelterInfo(String careRegNo) {
         return shelterQueryService.shelterInfo(careRegNo);
     }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterJpaRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterJpaRepository.java
@@ -1,8 +1,10 @@
 package kr.co.pawong.pwbe.shelter.infrastructure.repository;
 
 import kr.co.pawong.pwbe.shelter.infrastructure.repository.entity.ShelterEntity;
+import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -16,4 +18,9 @@ public interface ShelterJpaRepository extends JpaRepository<ShelterEntity, Long>
      */
     @Query("SELECT s.careRegNo FROM ShelterEntity s")
     List<String> findAllCareRegNos();
+
+    // adoption 에서 careRegNo를 받아 보호소 정보 반환
+    @Query("SELECT new kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto(s.careRegNo, s.city, s.district) " +
+            "FROM ShelterEntity s WHERE s.careRegNo = :careRegNo")
+    ShelterInfoDto shelterInfo(@Param("careRegNo") String careRegNo);
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterJpaRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterJpaRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface ShelterJpaRepository extends JpaRepository<ShelterEntity, Long> {
 
     List<ShelterEntity> findByCareNm(String careNm);
-    List<ShelterEntity> findByCareRegNo(String careRegNo);
+//    List<ShelterEntity> findByCareRegNo(String careRegNo);
 
     /**
      * 모든 ShelterEntity의 careRegNo만 추출해서 리스트로 반환하는 메서드
@@ -23,4 +23,6 @@ public interface ShelterJpaRepository extends JpaRepository<ShelterEntity, Long>
     @Query("SELECT new kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto(s.careRegNo, s.city, s.district) " +
             "FROM ShelterEntity s WHERE s.careRegNo = :careRegNo")
     ShelterInfoDto shelterInfo(@Param("careRegNo") String careRegNo);
+
+    ShelterEntity findByCareRegNo(String careRegNo);
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterQueryRepositoryImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterQueryRepositoryImpl.java
@@ -13,7 +13,9 @@ public class ShelterQueryRepositoryImpl implements ShelterQueryRepository {
 
     private final ShelterJpaRepository shelterJpaRepository;
 
+
     // adoption 에서 careRegNo를 받아 보호소 정보 반환
+    @Override
     public ShelterInfoDto shelterInfo(String careRegNo) {
         return shelterJpaRepository.shelterInfo(careRegNo);
     }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterQueryRepositoryImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package kr.co.pawong.pwbe.shelter.infrastructure.repository;
 
 import kr.co.pawong.pwbe.shelter.application.service.port.ShelterQueryRepository;
+import kr.co.pawong.pwbe.shelter.infrastructure.repository.entity.ShelterEntity;
 import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,4 +21,8 @@ public class ShelterQueryRepositoryImpl implements ShelterQueryRepository {
         return shelterJpaRepository.shelterInfo(careRegNo);
     }
 
+    @Override
+    public ShelterEntity findByCareRegNo(String careRegNo) {
+        return shelterJpaRepository.findByCareRegNo(careRegNo);
+    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterQueryRepositoryImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterQueryRepositoryImpl.java
@@ -1,0 +1,21 @@
+package kr.co.pawong.pwbe.shelter.infrastructure.repository;
+
+import kr.co.pawong.pwbe.shelter.application.service.port.ShelterQueryRepository;
+import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ShelterQueryRepositoryImpl implements ShelterQueryRepository {
+
+    private final ShelterJpaRepository shelterJpaRepository;
+
+    // adoption 에서 careRegNo를 받아 보호소 정보 반환
+    public ShelterInfoDto shelterInfo(String careRegNo) {
+        return shelterJpaRepository.shelterInfo(careRegNo);
+    }
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterUpdateRepositoryImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/infrastructure/repository/ShelterUpdateRepositoryImpl.java
@@ -25,7 +25,7 @@ public class ShelterUpdateRepositoryImpl implements ShelterUpdateRepository {
         shelterJpaRepository.saveAll(shelterEntities);
         log.info("{}개의 보호소 정보가 저장되었습니다.", shelters.size());
     }
-
+    @Override
     public List<String> findAllCareRegNos() {
         return shelterJpaRepository.findAllCareRegNos();
     }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/presentation/controller/ShelterUpdateController.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/presentation/controller/ShelterUpdateController.java
@@ -1,26 +1,27 @@
-package kr.co.pawong.pwbe.shelter.presentation.controller.dto;
+package kr.co.pawong.pwbe.shelter.presentation.controller;
 
 import kr.co.pawong.pwbe.shelter.application.domain.ShelterCreate;
 import kr.co.pawong.pwbe.shelter.application.service.ApiShelterService;
-import kr.co.pawong.pwbe.shelter.presentation.controller.port.ShelterUpdateService;
+import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
+import kr.co.pawong.pwbe.shelter.presentation.port.ShelterQueryService;
+import kr.co.pawong.pwbe.shelter.presentation.port.ShelterUpdateService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/shelter")
+@RequestMapping("/api/shelters")
 @RequiredArgsConstructor
 public class ShelterUpdateController {
 
     private final ApiShelterService apiShelterService;
     private final ShelterUpdateService shelterUpdateService;
+    private final ShelterQueryService  shelterQueryService;
 
     @PostMapping("/save")
     public ResponseEntity<Void> saveShelters() {
@@ -30,5 +31,14 @@ public class ShelterUpdateController {
         log.info("총 {}개의 동물보호센터가 성공적으로 저장되었습니다.", shelterCreates.size());
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/info/{care_Reg_No}")
+    public void shelterInfoDto(@PathVariable("care_Reg_No") String careRegNo) {
+        ShelterInfoDto shelterInfoDto = shelterQueryService.shelterInfo(careRegNo);
+
+        log.info("보호소 번호 : {}", shelterInfoDto.getCareRegNo());
+        log.info("도.시 : {}", shelterInfoDto.getCity());
+        log.info("시군구 : {}", shelterInfoDto.getDistrict());
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/presentation/controller/dto/ShelterInfoDto.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/presentation/controller/dto/ShelterInfoDto.java
@@ -1,0 +1,20 @@
+package kr.co.pawong.pwbe.shelter.presentation.controller.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ShelterInfoDto {
+    private String careRegNo; //동물보호센터번호
+    private String city; // 시도
+    private String district; // 시군구
+
+    public ShelterInfoDto(String careRegNo, String city, String district) {
+        this.careRegNo = careRegNo;
+        this.city = city;
+        this.district = district;
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/shelter/presentation/port/ShelterQueryService.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/presentation/port/ShelterQueryService.java
@@ -4,5 +4,5 @@ import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
 
 public interface ShelterQueryService {
 
-    ShelterInfoDto shelterInfo(String shelterId);
+    ShelterInfoDto shelterInfo(String careRegNo);
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/presentation/port/ShelterQueryService.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/presentation/port/ShelterQueryService.java
@@ -1,0 +1,8 @@
+package kr.co.pawong.pwbe.shelter.presentation.port;
+
+import kr.co.pawong.pwbe.shelter.presentation.controller.dto.ShelterInfoDto;
+
+public interface ShelterQueryService {
+
+    ShelterInfoDto shelterInfo(String shelterId);
+}

--- a/src/main/java/kr/co/pawong/pwbe/shelter/presentation/port/ShelterUpdateService.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/presentation/port/ShelterUpdateService.java
@@ -1,4 +1,4 @@
-package kr.co.pawong.pwbe.shelter.presentation.controller.port;
+package kr.co.pawong.pwbe.shelter.presentation.port;
 
 import kr.co.pawong.pwbe.shelter.application.domain.ShelterCreate;
 import java.util.List;


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
#23  -> develop

### 변경 사항
adoption에서 보호소번호로 보호소정보 요청시 shelter에서 city, district를 dto형태로 반환합니다.

### PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과
http://localhost:8080/api/adoption/7500/shelter로 요청시(테스트) 
![보호소 정보](https://github.com/user-attachments/assets/afe848f4-0ad6-4574-8fbb-d5e706572851) 제공

이후에는 save-es시 보호소정보를 document에 같이 저장

