### PR TITLE
[PW-39] 검색시 태그 매칭 추가

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionAiServiceImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionAiServiceImpl.java
@@ -24,7 +24,9 @@ public class AdoptionAiServiceImpl implements AdoptionAiService {
     // 문장 정제하는 함수
     @Override
     public String refineSpecialMark(String specialMark) {
-        validateNotBlank(specialMark);
+        if (!isValidateInput(specialMark)) {
+            return "";
+        }
         return chatPort.refineAdoptionSentence(specialMark);
     }
     // 위의 함수를 병렬로 수행하는 함수
@@ -36,7 +38,9 @@ public class AdoptionAiServiceImpl implements AdoptionAiService {
     // 입력된 문장에 대해 태그를 선택해서 문자열 리스트로 반환하는 함수
     @Override
     public List<String> tag(String feature) {
-        validateNotBlank(feature);
+        if (!isValidateInput(feature)) {
+            return List.of();
+        }
         return chatPort.getTagsByFeature(feature);
     }
     // 위의 함수를 병렬로 수행하는 함수
@@ -48,14 +52,10 @@ public class AdoptionAiServiceImpl implements AdoptionAiService {
     // 문장 임베딩하는 함수
     @Override
     public float[] embed(String completion) {
-        try {
-            validateNotBlank(completion);
-            return embeddingPort.embed(completion);
-        } catch (IllegalArgumentException e) {
-            log.warn("Invalid input for embedding: {}", e.getMessage());
+        if (!isValidateInput(completion)) {
             return new float[0]; // 빈 임베딩 반환 또는 다른 기본값
         }
-
+        return embeddingPort.embed(completion);
     }
     // 위의 함수를 병렬로 수행하는 함수
     @Override
@@ -64,10 +64,8 @@ public class AdoptionAiServiceImpl implements AdoptionAiService {
     }
 
     // 입력값 검증하는 함수
-    private void validateNotBlank(String input) {
-        if (input == null || input.isBlank()) {
-            throw new IllegalArgumentException("Input cannot be null or blank.");
-        }
+    private boolean isValidateInput(String input) {
+        return input != null && !input.isBlank();
     }
 
 

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionSearchServiceImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionSearchServiceImpl.java
@@ -48,7 +48,8 @@ public class AdoptionSearchServiceImpl implements AdoptionSearchService {
     public AdoptionIdSearchResponses searchDocumentIds(AdoptionSearchRequest request) {
 //        String refinedSearchTerm = refineSearchTerm(request);
         String refinedSearchTerm = request.getSearchTerm();
-        AdoptionSearchCondition condition = AdoptionSearchMapper.fromRequest(request, refinedSearchTerm, embed(refinedSearchTerm));
+        List<String> tags = tag(request);
+        AdoptionSearchCondition condition = AdoptionSearchMapper.fromRequest(request, refinedSearchTerm, tags, embed(refinedSearchTerm));
 
         List<Adoption> adoptions = adoptionSearchRepository.searchSimilarAdoptions(condition);
         return new AdoptionIdSearchResponses(adoptions.stream()
@@ -60,6 +61,11 @@ public class AdoptionSearchServiceImpl implements AdoptionSearchService {
     private String refineSearchTerm(AdoptionSearchRequest request) {
         String term = request.getSearchTerm();
         return adoptionAiService.refineSpecialMark(term);
+    }
+
+    // 위임, 태깅
+    private List<String> tag(AdoptionSearchRequest request) {
+        return adoptionAiService.tag(request.getSearchTerm());
     }
 
     // 위임, 임베딩 값

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionSearchServiceImpl.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/AdoptionSearchServiceImpl.java
@@ -46,7 +46,8 @@ public class AdoptionSearchServiceImpl implements AdoptionSearchService {
     // ES에서 검색 시 adoptionId를 반환
     @Override
     public AdoptionIdSearchResponses searchDocumentIds(AdoptionSearchRequest request) {
-        String refinedSearchTerm = refineSearchTerm(request);
+//        String refinedSearchTerm = refineSearchTerm(request);
+        String refinedSearchTerm = request.getSearchTerm();
         AdoptionSearchCondition condition = AdoptionSearchMapper.fromRequest(request, refinedSearchTerm, embed(refinedSearchTerm));
 
         List<Adoption> adoptions = adoptionSearchRepository.searchSimilarAdoptions(condition);

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/dto/request/AdoptionEsDto.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/dto/request/AdoptionEsDto.java
@@ -10,6 +10,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -23,7 +25,7 @@ public class AdoptionEsDto {
     private String city;
     private String district;
     private String refinedSpecialMark;
-    private String tagsField;
+    private List<String> tagsField;
     private float[] embedding;
 
     public static AdoptionEsDto from(Adoption adoption, RegionInfoDto regionInfo) {
@@ -36,7 +38,7 @@ public class AdoptionEsDto {
                 .city(regionInfo.getCity())
                 .district(regionInfo.getDistrict())
                 .refinedSpecialMark(adoption.getRefinedSpecialMark())
-                .tagsField(adoption.getTagsField())
+                .tagsField(adoption.getTagsField() == null ? List.of() : List.of(adoption.getTagsField().split(",")))
                 .embedding(adoption.getEmbedding())
                 .build();
     }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/dto/request/AdoptionSearchCondition.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/dto/request/AdoptionSearchCondition.java
@@ -16,6 +16,7 @@ public class AdoptionSearchCondition {
     private NeuterYn neuterYn;
     private List<Region> regions;
     private String refinedSearchTerm;   // 정제된 검색어 문장
+    private List<String> tags;
     private float[] embedding;
 
     /** city/district 를 담는 DTO **/

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/support/AdoptionQueryBuilder.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/support/AdoptionQueryBuilder.java
@@ -84,6 +84,17 @@ public class AdoptionQueryBuilder {
       ));
     }
 
+    // tags가 있으면 tagsField에 terms 매칭 추가
+    if (condition.getTags() != null && !condition.getTags().isEmpty()) {
+      for (String tag : condition.getTags()) {
+        semantic.should(s -> s.term(t -> t
+                .field("tagsField")
+                .value(tag)
+                .boost(4.0f)      // 각 태그 매칭 시 점수 가중치
+        ));
+      }
+    }
+
     if (condition.getEmbedding() != null && condition.getEmbedding().length == 1536) {
       List<Float> embeddingList = new ArrayList<>(condition.getEmbedding().length);
       for (float f : condition.getEmbedding()) {
@@ -97,7 +108,7 @@ public class AdoptionQueryBuilder {
                   .source("cosineSimilarity(params.query_vector, 'embedding') + 1.0") // cosine similarity 활용
                   .params("query_vector", JsonData.of(embeddingList))
               ))
-              .boost(2.0f)    // 벡터는 2배의 가중치
+              .boost(4.0f)    // 벡터는 2배의 가중치
           ));
     }
 

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/support/AdoptionSearchMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/support/AdoptionSearchMapper.java
@@ -11,13 +11,14 @@ import kr.co.pawong.pwbe.adoption.presentation.controller.dto.response.AdoptionI
 
 public class AdoptionSearchMapper {
 
-    public static AdoptionSearchCondition fromRequest(AdoptionSearchRequest request, String refinedSearchTerm, float[] embedding) {
+    public static AdoptionSearchCondition fromRequest(AdoptionSearchRequest request, String refinedSearchTerm, List<String> tags, float[] embedding) {
         return AdoptionSearchCondition.builder()
                 .upKindCds(request.getUpKindCds())
                 .sexCd(request.getSexCd())
                 .neuterYn(request.getNeuterYn())
                 .regions(toRegionList(request.getRegions()))
                 .refinedSearchTerm(refinedSearchTerm)
+                .tags(tags)
                 .embedding(embedding)
                 .build();
     }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/document/AdoptionDocument.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/infrastructure/repository/document/AdoptionDocument.java
@@ -15,6 +15,8 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -45,8 +47,8 @@ public class AdoptionDocument {
     private String refinedSpecialMark; // AI가 정제한 동물 정보
 
     @Setter
-    @Field(type = FieldType.Text, name = "tagsField", analyzer = "korean")
-    private String tagsField; // AI가 키워드로 정제한 동물 정보
+    @Field(type = FieldType.Keyword, name = "tagsField")
+    private List<String> tagsField; // AI가 키워드로 정제한 동물 정보
 
     @Setter
     @Field(type = FieldType.Dense_Vector, dims = 1536, name = "embedding")
@@ -73,7 +75,7 @@ public class AdoptionDocument {
                 .sexCd(this.sexCd)
                 .neuterYn(this.neuterYn)
                 .refinedSpecialMark(this.refinedSpecialMark)
-                .tagsField(this.tagsField)
+                .tagsField(String.join(",", this.tagsField))
                 .embedding(this.embedding)
                 .build();
     }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#39 -> develop

### 변경 사항
- AI 기능 사용시에 예외를 던지던 것을 삭제했습니다.
- `Adoption` document를 수정했습니다. (`tagsField`를 `List<String>`으로 수정)
그거에 맞춰서 노션에 수정한 인덱스로 인덱스를 다시 생성하셔야합니다.
![image](https://github.com/user-attachments/assets/ea4645f8-c8f7-4ffe-acb3-f43715eb233c)

- document 수정에 따라서 변환 함수들을 수정했습니다. (도메인<-> 엔티티, 도메인 <-> 도큐먼트)
- 검색 쿼리에 태그 매칭 조건을 추가했습니다.

**양해 사항**
- 코드는 수정했지만 테스트는 그거에 맞춰서 수정하지 못했습니다. 추후 수정하겠습니다.

### PR 체크리스트
- [ ] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과
현재 테스트는 실패합니다. 추후 테스트 코드 수정하겠습니다.
빌드와 검색은 정상적으로 동작합니다.
